### PR TITLE
:bug: fix not working link on click

### DIFF
--- a/src/components/ui/Autocomplete/index.tsx
+++ b/src/components/ui/Autocomplete/index.tsx
@@ -122,6 +122,7 @@ const Autocomplete: React.FC<AutocompleteProps> = ({ title, autocomplete }) => {
                   <a
                     href={item.href}
                     id={`${autocompleteId}_item_${i}`}
+                    onMouseDown={(e) => e.preventDefault()}
                     className="
                       block
                       px-4 py-1


### PR DESCRIPTION
## Overview

Fix the link in the autocomplete menu was not working on click.